### PR TITLE
Feat/chat

### DIFF
--- a/src/main/java/org/gdsccau/team5/safebridge/domain/chat/controller/ChatController.java
+++ b/src/main/java/org/gdsccau/team5/safebridge/domain/chat/controller/ChatController.java
@@ -14,7 +14,6 @@ import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,12 +32,12 @@ public class ChatController {
 
     @GetMapping("/chats/teams/{teamId}")
     public ApiResponse<Map<String, Object>> getMessages(
-//            @RequestHeader("Authorization") final String token,
             @PathVariable(name = "teamId") final Long teamId,
             @RequestParam(name = "userId") final Long userId,
-            @RequestParam(name = "cursorId", required = false) final Long cursorId) {
+            @RequestParam(name = "cursorId", required = false) final Long cursorId,
+            @RequestParam(name = "role") final String role) {
         return ApiResponse.onSuccess(ChatSuccessCode.FIND_CHAT_IN_TEAM,
-                chatFacade.findAllChats(cursorId, userId, teamId));
+                chatFacade.findAllChats(role, cursorId, userId, teamId));
     }
 
     @GetMapping("/chats/works")

--- a/src/main/java/org/gdsccau/team5/safebridge/domain/chat/controller/ChatController.java
+++ b/src/main/java/org/gdsccau/team5/safebridge/domain/chat/controller/ChatController.java
@@ -14,6 +14,7 @@ import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,6 +33,7 @@ public class ChatController {
 
     @GetMapping("/chats/teams/{teamId}")
     public ApiResponse<Map<String, Object>> getMessages(
+//            @RequestHeader("Authorization") final String token,
             @PathVariable(name = "teamId") final Long teamId,
             @RequestParam(name = "userId") final Long userId,
             @RequestParam(name = "cursorId", required = false) final Long cursorId) {

--- a/src/main/java/org/gdsccau/team5/safebridge/domain/chat/facade/ChatFacade.java
+++ b/src/main/java/org/gdsccau/team5/safebridge/domain/chat/facade/ChatFacade.java
@@ -58,13 +58,11 @@ public class ChatFacade {
         return chatService.createChat(chatRequestDto, user, team);
     }
 
-    public Map<String, Object> findAllChats(final Long cursorId, final Long userId,
+    public Map<String, Object> findAllChats(final String role, final Long cursorId, final Long userId,
                                             final Long teamId) {
-        // TODO token에서 Role 꺼내서 findAllChatsByTeamId에 넘겨주기
-        Role role = Role.ADMIN; // 임시 코드
-
         Language language = userCheckService.findLanguageByUserId(userId);
-        Slice<ChatMessageWithIsReadResponseDto> chatSlice = chatCheckService.findAllChatsByTeamId(role, cursorId,
+        Slice<ChatMessageWithIsReadResponseDto> chatSlice = chatCheckService.findAllChatsByTeamId(Role.valueOf(role),
+                cursorId,
                 teamId, language);
         LocalDateTime accessDate = userTeamCheckService.findAccessDateByUserIdAndTeamId(userId, teamId);
         for (ChatMessageWithIsReadResponseDto chatMessage : chatSlice.getContent()) {

--- a/src/main/java/org/gdsccau/team5/safebridge/domain/chat/facade/ChatFacade.java
+++ b/src/main/java/org/gdsccau/team5/safebridge/domain/chat/facade/ChatFacade.java
@@ -19,6 +19,7 @@ import org.gdsccau.team5.safebridge.domain.chat.service.ChatService;
 import org.gdsccau.team5.safebridge.domain.team.entity.Team;
 import org.gdsccau.team5.safebridge.domain.team.service.TeamCheckService;
 import org.gdsccau.team5.safebridge.domain.user.entity.User;
+import org.gdsccau.team5.safebridge.domain.user.enums.Role;
 import org.gdsccau.team5.safebridge.domain.user.service.UserCheckService;
 import org.gdsccau.team5.safebridge.domain.user_team.service.UserTeamCheckService;
 import org.springframework.data.domain.Slice;
@@ -57,10 +58,14 @@ public class ChatFacade {
         return chatService.createChat(chatRequestDto, user, team);
     }
 
-    public Map<String, Object> findAllChats(final Long cursorId, final Long userId, final Long teamId) {
+    public Map<String, Object> findAllChats(final Long cursorId, final Long userId,
+                                            final Long teamId) {
+        // TODO token에서 Role 꺼내서 findAllChatsByTeamId에 넘겨주기
+        Role role = Role.ADMIN; // 임시 코드
+
         Language language = userCheckService.findLanguageByUserId(userId);
-        Slice<ChatMessageWithIsReadResponseDto> chatSlice = chatCheckService.findAllChatsByTeamId(cursorId, teamId,
-                language);
+        Slice<ChatMessageWithIsReadResponseDto> chatSlice = chatCheckService.findAllChatsByTeamId(role, cursorId,
+                teamId, language);
         LocalDateTime accessDate = userTeamCheckService.findAccessDateByUserIdAndTeamId(userId, teamId);
         for (ChatMessageWithIsReadResponseDto chatMessage : chatSlice.getContent()) {
             chatMessage.setRead(chatMessage.getSendTime().isBefore(accessDate));

--- a/src/main/java/org/gdsccau/team5/safebridge/domain/chat/repository/ChatCustomRepository.java
+++ b/src/main/java/org/gdsccau/team5/safebridge/domain/chat/repository/ChatCustomRepository.java
@@ -2,12 +2,14 @@ package org.gdsccau.team5.safebridge.domain.chat.repository;
 
 import org.gdsccau.team5.safebridge.common.term.Language;
 import org.gdsccau.team5.safebridge.domain.chat.dto.response.ChatResponseDto.ChatMessageWithIsReadResponseDto;
+import org.gdsccau.team5.safebridge.domain.user.enums.Role;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface ChatCustomRepository {
 
-    Slice<ChatMessageWithIsReadResponseDto> findAllChatsByTeamId(final Long cursorId,
+    Slice<ChatMessageWithIsReadResponseDto> findAllChatsByTeamId(final Role role,
+                                                                 final Long cursorId,
                                                                  final Long teamId,
                                                                  final Language language,
                                                                  final Pageable pageable);

--- a/src/main/java/org/gdsccau/team5/safebridge/domain/chat/repository/ChatCustomRepositoryImpl.java
+++ b/src/main/java/org/gdsccau/team5/safebridge/domain/chat/repository/ChatCustomRepositoryImpl.java
@@ -5,6 +5,7 @@ import static org.gdsccau.team5.safebridge.domain.chat.entity.QChat.chat;
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
@@ -59,7 +60,6 @@ public class ChatCustomRepositoryImpl implements ChatCustomRepository {
     ) {
         QChat chat = QChat.chat;
         QUser user = QUser.user;
-        QTranslation translation = QTranslation.translation;
         return queryFactory
                 .select(Projections.constructor(
                         ChatMessageWithIsReadResponseDto.class,
@@ -67,13 +67,12 @@ public class ChatCustomRepositoryImpl implements ChatCustomRepository {
                         user.id,
                         user.name,
                         chat.text,
-                        translation.text,
+                        Expressions.nullExpression(String.class),
                         ConstantImpl.create(false),
                         chat.createdAt
                 ))
                 .from(chat)
                 .join(user).on(user.id.eq(chat.user.id))
-                .join(translation).on(translation.chat.id.eq(chat.id))
                 .where(
                         chat.team.id.eq(teamId)
                                 .and(eqCursorId(cursorId))

--- a/src/main/java/org/gdsccau/team5/safebridge/domain/chat/repository/ChatCustomRepositoryImpl.java
+++ b/src/main/java/org/gdsccau/team5/safebridge/domain/chat/repository/ChatCustomRepositoryImpl.java
@@ -7,12 +7,14 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
 import java.util.List;
 import org.gdsccau.team5.safebridge.common.term.Language;
 import org.gdsccau.team5.safebridge.domain.chat.dto.response.ChatResponseDto.ChatMessageWithIsReadResponseDto;
 import org.gdsccau.team5.safebridge.domain.chat.entity.QChat;
 import org.gdsccau.team5.safebridge.domain.translation.entity.QTranslation;
 import org.gdsccau.team5.safebridge.domain.user.entity.QUser;
+import org.gdsccau.team5.safebridge.domain.user.enums.Role;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -21,55 +23,102 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class ChatCustomRepositoryImpl implements ChatCustomRepository {
 
-  private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory queryFactory;
 
-  public ChatCustomRepositoryImpl(final EntityManager entityManager) {
-    this.queryFactory = new JPAQueryFactory(entityManager);
-  }
-
-  @Override
-  public Slice<ChatMessageWithIsReadResponseDto> findAllChatsByTeamId(final Long cursorId,
-      final Long teamId,
-      final Language language,
-      final Pageable pageable) {
-    QChat chat = QChat.chat;
-    QUser user = QUser.user;
-    QTranslation translation = QTranslation.translation;
-
-    List<ChatMessageWithIsReadResponseDto> results = queryFactory
-        .select(Projections.constructor(
-            ChatMessageWithIsReadResponseDto.class,
-            chat.id,
-            user.id,
-            user.name,
-            chat.text,
-            translation.text,
-            ConstantImpl.create(false),
-            chat.createdAt
-        ))
-        .from(chat)
-        .join(user).on(user.id.eq(chat.user.id))
-        .join(translation).on(translation.chat.id.eq(chat.id)).on(translation.language.eq(language))
-        .where(
-            chat.team.id.eq(teamId)
-                .and(eqCursorId(cursorId))
-        )
-        .orderBy(chat.id.desc())
-        .limit(pageable.getPageSize() + 1)
-        .fetch();
-
-    boolean hasNext = false;
-    if (results.size() > pageable.getPageSize()) {
-      results.remove(pageable.getPageSize());
-      hasNext = true;
+    public ChatCustomRepositoryImpl(final EntityManager entityManager) {
+        this.queryFactory = new JPAQueryFactory(entityManager);
     }
-    return new SliceImpl<>(results, pageable, hasNext);
-  }
 
-  private BooleanExpression eqCursorId(final Long cursorId) {
-    if (cursorId != null && cursorId != 0L) {
-      return chat.id.lt(cursorId);
+    @Override
+    public Slice<ChatMessageWithIsReadResponseDto> findAllChatsByTeamId(
+            final Role role,
+            final Long cursorId,
+            final Long teamId,
+            final Language language,
+            final Pageable pageable) {
+
+        List<ChatMessageWithIsReadResponseDto> results;
+        if (role.equals(Role.ADMIN)) {
+            results = this.adminQuery(cursorId, teamId, pageable);
+        } else {
+            results = this.memberQuery(cursorId, teamId, language, pageable);
+        }
+
+        boolean hasNext = false;
+        if (results.size() > pageable.getPageSize()) {
+            results.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+        return new SliceImpl<>(results, pageable, hasNext);
     }
-    return null;
-  }
+
+    private List<ChatMessageWithIsReadResponseDto> adminQuery(
+            final Long cursorId,
+            final Long teamId,
+            final Pageable pageable
+    ) {
+        QChat chat = QChat.chat;
+        QUser user = QUser.user;
+        QTranslation translation = QTranslation.translation;
+        return queryFactory
+                .select(Projections.constructor(
+                        ChatMessageWithIsReadResponseDto.class,
+                        chat.id,
+                        user.id,
+                        user.name,
+                        chat.text,
+                        translation.text,
+                        ConstantImpl.create(false),
+                        chat.createdAt
+                ))
+                .from(chat)
+                .join(user).on(user.id.eq(chat.user.id))
+                .join(translation).on(translation.chat.id.eq(chat.id))
+                .where(
+                        chat.team.id.eq(teamId)
+                                .and(eqCursorId(cursorId))
+                )
+                .orderBy(chat.id.desc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+    }
+
+    private List<ChatMessageWithIsReadResponseDto> memberQuery(
+            final Long cursorId,
+            final Long teamId,
+            final Language language,
+            final Pageable pageable
+    ) {
+        QChat chat = QChat.chat;
+        QUser user = QUser.user;
+        QTranslation translation = QTranslation.translation;
+        return queryFactory
+                .select(Projections.constructor(
+                        ChatMessageWithIsReadResponseDto.class,
+                        chat.id,
+                        user.id,
+                        user.name,
+                        chat.text,
+                        translation.text,
+                        ConstantImpl.create(false),
+                        chat.createdAt
+                ))
+                .from(chat)
+                .join(user).on(user.id.eq(chat.user.id))
+                .join(translation).on(translation.chat.id.eq(chat.id)).on(translation.language.eq(language))
+                .where(
+                        chat.team.id.eq(teamId)
+                                .and(eqCursorId(cursorId))
+                )
+                .orderBy(chat.id.desc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+    }
+
+    private BooleanExpression eqCursorId(final Long cursorId) {
+        if (cursorId != null && cursorId != 0L) {
+            return chat.id.lt(cursorId);
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/gdsccau/team5/safebridge/domain/chat/service/ChatCheckService.java
+++ b/src/main/java/org/gdsccau/team5/safebridge/domain/chat/service/ChatCheckService.java
@@ -13,6 +13,7 @@ import org.gdsccau.team5.safebridge.domain.chat.dto.response.ChatResponseDto.Wor
 import org.gdsccau.team5.safebridge.domain.chat.entity.Chat;
 import org.gdsccau.team5.safebridge.domain.chat.repository.ChatCustomRepository;
 import org.gdsccau.team5.safebridge.domain.chat.repository.ChatRepository;
+import org.gdsccau.team5.safebridge.domain.user.enums.Role;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -46,11 +47,12 @@ public class ChatCheckService {
     }
 
     @Transactional(readOnly = true)
-    public Slice<ChatMessageWithIsReadResponseDto> findAllChatsByTeamId(final Long cursorId,
+    public Slice<ChatMessageWithIsReadResponseDto> findAllChatsByTeamId(final Role role,
+                                                                        final Long cursorId,
                                                                         final Long teamId,
                                                                         final Language language) {
         Pageable pageable = PageRequest.of(0, 5);
-        Slice<ChatMessageWithIsReadResponseDto> dtos = chatCustomRepository.findAllChatsByTeamId(cursorId, teamId,
+        Slice<ChatMessageWithIsReadResponseDto> dtos = chatCustomRepository.findAllChatsByTeamId(role, cursorId, teamId,
                 language, pageable);
         this.validateChatData(dtos.getContent());
         return dtos;

--- a/src/main/java/org/gdsccau/team5/safebridge/domain/chat/service/ChatSendService.java
+++ b/src/main/java/org/gdsccau/team5/safebridge/domain/chat/service/ChatSendService.java
@@ -1,6 +1,9 @@
 package org.gdsccau.team5.safebridge.domain.chat.service;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,11 +11,15 @@ import org.gdsccau.team5.safebridge.common.redis.RedisManager;
 import org.gdsccau.team5.safebridge.common.term.Language;
 import org.gdsccau.team5.safebridge.common.term.TermManager;
 import org.gdsccau.team5.safebridge.domain.chat.converter.ChatConverter;
+import org.gdsccau.team5.safebridge.domain.chat.dto.ChatDto.TermDataDto;
 import org.gdsccau.team5.safebridge.domain.chat.dto.ChatDto.TermDataWithNewChatDto;
 import org.gdsccau.team5.safebridge.domain.chat.dto.ChatDto.TranslatedDataDto;
 import org.gdsccau.team5.safebridge.domain.chat.entity.Chat;
 import org.gdsccau.team5.safebridge.domain.team.dto.response.TeamResponseDto.TeamListDto;
 import org.gdsccau.team5.safebridge.domain.team.service.TeamCheckService;
+import org.gdsccau.team5.safebridge.domain.term.service.TermCheckService;
+import org.gdsccau.team5.safebridge.domain.translatedTerm.service.TranslatedTermCheckService;
+import org.gdsccau.team5.safebridge.domain.translation.service.TranslationCheckService;
 import org.gdsccau.team5.safebridge.domain.translation.service.TranslationService;
 import org.gdsccau.team5.safebridge.domain.user_team.service.UserTeamCheckService;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -28,6 +35,9 @@ public class ChatSendService {
     private static final String TRANSLATE_SUB_URL = "/sub/translate/";
 
     private final TranslationService translationService;
+    private final TranslationCheckService translationCheckService;
+    private final TranslatedTermCheckService translatedTermCheckService;
+    private final TermCheckService termCheckService;
     private final TeamCheckService teamCheckService;
     private final UserTeamCheckService userTeamCheckService;
     private final SimpMessagingTemplate messagingTemplate;
@@ -42,14 +52,34 @@ public class ChatSendService {
 
     public void sendTranslatedMessage(final TermDataWithNewChatDto result, final Language language, final Chat chat,
                                       final Long teamId, final Long userId) {
-        CompletableFuture<TranslatedDataDto> translatedText = termManager.translate(
-                result.getNewChat(), result.getTerms(), language);
-        translatedText.thenAccept(dto -> {
-            translationService.createTranslation(dto.getTranslatedText(), language, chat.getId());
+        // TODO 이미 번역되었다면 (같은 문장, 다른 사람, 같은 언어) 번역 API를 호출하지 않는다.
+        if (translationCheckService.isTranslationExists(chat.getId(), language)) {
+            Map<String, String> wordZip = new HashMap<>();
+
+            List<String> words = result.getTerms().stream()
+                    .map(TermDataDto::getTerm)
+                    .toList();
+            for (String word : words) {
+                Long termId = termCheckService.findTermIdByWord(word);
+                String translatedWord = translatedTermCheckService.findTranslatedTermByLanguageAndTermId(language,
+                        termId);
+                wordZip.put(word, translatedWord);
+            }
+            String translatedText = translationCheckService.findTranslatedTextByChatIdAndLanguage(chat.getId(),
+                    language);
             messagingTemplate.convertAndSend(TRANSLATE_SUB_URL + teamId + "/" + userId,
-                    ChatConverter.toTranslatedTextResponseDto(dto.getTranslatedText(), dto.getTranslatedTerms(), chat.getId()));
-        });
-        // TODO 예외처리
+                    ChatConverter.toTranslatedTextResponseDto(translatedText, wordZip, chat.getId()));
+        } else {
+            CompletableFuture<TranslatedDataDto> translatedText = termManager.translate(
+                    result.getNewChat(), result.getTerms(), language);
+            translatedText.thenAccept(dto -> {
+                translationService.createTranslation(dto.getTranslatedText(), language, chat.getId());
+                messagingTemplate.convertAndSend(TRANSLATE_SUB_URL + teamId + "/" + userId,
+                        ChatConverter.toTranslatedTextResponseDto(dto.getTranslatedText(), dto.getTranslatedTerms(),
+                                chat.getId()));
+            });
+            // TODO 예외처리
+        }
     }
 
     public void sendTeamData(final Chat chat, final Long teamId, final Long userId) {

--- a/src/main/java/org/gdsccau/team5/safebridge/domain/term/repository/TermRepository.java
+++ b/src/main/java/org/gdsccau/team5/safebridge/domain/term/repository/TermRepository.java
@@ -9,4 +9,7 @@ public interface TermRepository extends JpaRepository<Term, Long> {
 
     @Query("SELECT t FROM Term t WHERE t.word = :word")
     Optional<Term> findTermByWord(final String word);
+
+    @Query("SELECT t.id FROM Term t WHERE t.word = :word")
+    Optional<Long> findTermIdByWord(final String word);
 }

--- a/src/main/java/org/gdsccau/team5/safebridge/domain/term/service/TermCheckService.java
+++ b/src/main/java/org/gdsccau/team5/safebridge/domain/term/service/TermCheckService.java
@@ -1,6 +1,5 @@
 package org.gdsccau.team5.safebridge.domain.term.service;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.gdsccau.team5.safebridge.domain.term.entity.Term;
@@ -16,5 +15,9 @@ public class TermCheckService {
 
     public Term findTermByWord(final String word) {
         return termRepository.findTermByWord(word).orElse(null);
+    }
+
+    public Long findTermIdByWord(final String word) {
+        return termRepository.findTermIdByWord(word).orElse(null);
     }
 }

--- a/src/main/java/org/gdsccau/team5/safebridge/domain/translatedTerm/service/TranslatedTermCheckService.java
+++ b/src/main/java/org/gdsccau/team5/safebridge/domain/translatedTerm/service/TranslatedTermCheckService.java
@@ -17,5 +17,4 @@ public class TranslatedTermCheckService {
     public String findTranslatedTermByLanguageAndTermId(final Language language, final Long termId) {
         return translatedTermRepository.findTranslatedTermByLanguageAndTermId(language, termId).orElse(null);
     }
-
 }

--- a/src/main/java/org/gdsccau/team5/safebridge/domain/translation/TranslationRepository.java
+++ b/src/main/java/org/gdsccau/team5/safebridge/domain/translation/TranslationRepository.java
@@ -1,8 +1,17 @@
 package org.gdsccau.team5.safebridge.domain.translation;
 
 
+import java.util.Optional;
+import org.gdsccau.team5.safebridge.common.term.Language;
 import org.gdsccau.team5.safebridge.domain.translation.entity.Translation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TranslationRepository extends JpaRepository<Translation, Long> {
+
+    @Query("SELECT count(t) > 0 FROM Translation t WHERE t.chat.id = :chatId AND t.language = :language")
+    boolean existsByChatIdAndLanguage(final Long chatId, final Language language);
+
+    @Query("SELECT t.text FROM Translation t WHERE t.chat.id = :chatId AND t.language = :language")
+    Optional<String> findTranslatedTextByChatIdAndLanguage(final Long chatId, final Language language);
 }

--- a/src/main/java/org/gdsccau/team5/safebridge/domain/translation/service/TranslationCheckService.java
+++ b/src/main/java/org/gdsccau/team5/safebridge/domain/translation/service/TranslationCheckService.java
@@ -2,6 +2,7 @@ package org.gdsccau.team5.safebridge.domain.translation.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.gdsccau.team5.safebridge.common.term.Language;
 import org.gdsccau.team5.safebridge.domain.translation.TranslationRepository;
 import org.springframework.stereotype.Service;
 
@@ -12,4 +13,11 @@ public class TranslationCheckService {
 
     private final TranslationRepository translationRepository;
 
+    public boolean isTranslationExists(final Long chatId, final Language language) {
+        return translationRepository.existsByChatIdAndLanguage(chatId, language);
+    }
+
+    public String findTranslatedTextByChatIdAndLanguage(final Long chatId, final Language language) {
+        return translationRepository.findTranslatedTextByChatIdAndLanguage(chatId, language).orElse(null);
+    }
 }


### PR DESCRIPTION
## 추가된 기능
- 동일 채팅 / 동일 언어에 대해 번역 API 중복 호출을 방지한다.
- 채팅메시지에 대해 Admin, Member를 구분하여 Admin의 경우에 번역 문장이 존재하지 않으므로 Null 값을 보낸다.